### PR TITLE
Render content from CMS to all pages + add preview template 

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -9,6 +9,15 @@ module.exports = {
     },
   },
   plugins: [
+    `gatsby-transformer-sharp`,
+    `gatsby-plugin-sharp`,
+    `gatsby-plugin-react-helmet`,
+    {
+      resolve: `gatsby-transformer-remark`,
+      options: {
+        plugins: [`gatsby-plugin-netlify-cms-paths`],
+      },
+    },
     `gatsby-plugin-sass`,
     `gatsby-plugin-netlify-cms`,
     {
@@ -43,15 +52,6 @@ module.exports = {
       resolve: `gatsby-plugin-typography`,
       options: {
         pathToConfigModule: `src/utils/typography`,
-      },
-    },
-    `gatsby-transformer-sharp`,
-    `gatsby-plugin-sharp`,
-    `gatsby-plugin-react-helmet`,
-    {
-      resolve: `gatsby-transformer-remark`,
-      options: {
-        plugins: [`gatsby-plugin-netlify-cms-paths`],
       },
     },
   ],

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -37,6 +37,13 @@ module.exports = {
     {
       resolve: `gatsby-source-filesystem`,
       options: {
+        path: `${__dirname}/src/cms/history`,
+        name: `history`,
+      },
+    },
+    {
+      resolve: `gatsby-source-filesystem`,
+      options: {
         path: `${__dirname}/src/cms/images`,
         name: `CMSimages`,
       },

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -9,8 +9,8 @@ module.exports = {
     },
   },
   plugins: [
-    `gatsby-transformer-sharp`,
     `gatsby-plugin-sharp`,
+    `gatsby-transformer-sharp`,
     `gatsby-plugin-react-helmet`,
     {
       resolve: `gatsby-transformer-remark`,
@@ -44,6 +44,13 @@ module.exports = {
     {
       resolve: `gatsby-source-filesystem`,
       options: {
+        path: `${__dirname}/src/cms/contact`,
+        name: `contact`,
+      },
+    },
+    {
+      resolve: `gatsby-source-filesystem`,
+      options: {
         path: `${__dirname}/src/cms/images`,
         name: `CMSimages`,
       },
@@ -55,7 +62,6 @@ module.exports = {
         name: `images`,
       },
     },
-    `gatsby-transformer-remark`,
     {
       resolve: `gatsby-plugin-typography`,
       options: {

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -51,6 +51,20 @@ module.exports = {
     {
       resolve: `gatsby-source-filesystem`,
       options: {
+        path: `${__dirname}/src/cms/awards`,
+        name: `awards`,
+      },
+    },
+    {
+      resolve: `gatsby-source-filesystem`,
+      options: {
+        path: `${__dirname}/src/cms/about`,
+        name: `about`,
+      },
+    },
+    {
+      resolve: `gatsby-source-filesystem`,
+      options: {
         path: `${__dirname}/src/cms/images`,
         name: `CMSimages`,
       },

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -19,7 +19,12 @@ module.exports = {
       },
     },
     `gatsby-plugin-sass`,
-    `gatsby-plugin-netlify-cms`,
+    {
+      resolve: 'gatsby-plugin-netlify-cms',
+      options: {
+        modulePath: `${__dirname}/src/cms/cms.js`,
+      },
+    },
     {
       resolve: `gatsby-source-filesystem`,
       options: {

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -55,6 +55,7 @@ module.exports = {
         name: `images`,
       },
     },
+    `gatsby-transformer-remark`,
     {
       resolve: `gatsby-plugin-typography`,
       options: {

--- a/src/cms/cms.js
+++ b/src/cms/cms.js
@@ -1,0 +1,5 @@
+import CMS from 'netlify-cms-app'
+
+import ContactPagePreview from './preview-templates/ContactPagePreview'
+
+CMS.registerPreviewTemplate('contact', ContactPagePreview)

--- a/src/cms/cms.js
+++ b/src/cms/cms.js
@@ -1,5 +1,7 @@
 import CMS from 'netlify-cms-app'
 
 import ContactPagePreview from './preview-templates/ContactPagePreview'
+import AboutPagePreview from './preview-templates/AboutPagePreview'
 
+// CMS.registerPreviewTemplate('about', AboutPagePreview)
 CMS.registerPreviewTemplate('contact', ContactPagePreview)

--- a/src/cms/preview-templates/AboutPagePreview.js
+++ b/src/cms/preview-templates/AboutPagePreview.js
@@ -1,0 +1,78 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import AboutPageTemplate from '../../templates/AboutPageTemplate'
+
+const AboutPagePreview = ({ entry, getAsset, widgetFor }) => {
+  return (
+    <AboutPageTemplate
+      title={entry.getIn(['data', 'title'])}
+      subheading={entry.getIn(['data', 'subheading'])}
+      sectionOne={{
+        heading: entry.getIn(['data', 'sectionOne', 'heading']),
+        text1: entry.getIn(['data', 'sectionOne', 'text1']),
+        text2: entry.getIn(['data', 'sectionOne', 'text2']),
+        // image: {
+        //   image: getAsset(
+        //     entry.getIn(['data', 'sectionOne', 'image', 'image'])
+        //   ),
+        //   childImageSharp: {
+        //     childImageSharp: getAsset(
+        //       entry.getIn(['data', 'sectionOne', 'image', 'childImageSharp'])
+        //     ),
+        //   },
+        // },
+      }}
+      sectionTwo={{
+        heading: entry.getIn(['data', 'sectionTwo', 'heading']),
+        column1: entry.getIn(['data', 'sectionTwo', 'column1']),
+        column2: entry.getIn(['data', 'sectionTwo', 'column2']),
+      }}
+      sectionThree={{
+        heading: entry.getIn(['data', 'sectionThree', 'heading']),
+        boardMemberOne: {
+          name: entry.getIn(['data', 'sectionThree', 'boardMemberOne', 'name']),
+          text: entry.getIn(['data', 'sectionThree', 'boardMemberOne', 'text']),
+          // image: entry.getIn([
+          //   'data',
+          //   'sectionThree',
+          //   'boardMemberOne',
+          //   'image',
+          // ]),
+        },
+        boardMemberTwo: {
+          name: entry.getIn(['data', 'sectionThree', 'boardMemberTwo', 'name']),
+          text: entry.getIn(['data', 'sectionThree', 'boardMemberTwo', 'text']),
+          // image: entry.getIn([
+          //   'data',
+          //   'sectionThree',
+          //   'boardMemberTwo',
+          //   'image',
+          // ]),
+        },
+      }}
+      sectionFour={{
+        heading: entry.getIn(['data', 'sectionFour', 'heading']),
+        employeeOne: {
+          name: entry.getIn(['data', 'sectionFour', 'employeeOne', 'name']),
+          text: entry.getIn(['data', 'sectionFour', 'employeeOne', 'text']),
+          // image: entry.getIn(['data', 'sectionFour', 'employeeOne', 'image']),
+        },
+        employeeTwo: {
+          name: entry.getIn(['data', 'sectionFour', 'employeeTwo', 'name']),
+          text: entry.getIn(['data', 'sectionFour', 'employeeTwo', 'text']),
+          // image: entry.getIn(['data', 'sectionFour', 'employeeTwo', 'image']),
+        },
+      }}
+    />
+  )
+}
+
+export default AboutPagePreview
+
+AboutPagePreview.propTypes = {
+  entry: PropTypes.shape({
+    getIn: PropTypes.func,
+  }),
+  widgetFor: PropTypes.func,
+  getAsset: PropTypes.func,
+}

--- a/src/cms/preview-templates/ContactPagePreview.js
+++ b/src/cms/preview-templates/ContactPagePreview.js
@@ -1,0 +1,21 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { ContactPageTemplate } from '../../pages/contact'
+
+const ContactPagePreview = ({ entry, widgetFor }) => {
+  return (
+    <ContactPageTemplate
+      title={entry.getIn(['data', 'title'])}
+      content={widgetFor('body')}
+    />
+  )
+}
+
+ContactPagePreview.propTypes = {
+  entry: PropTypes.shape({
+    getIn: PropTypes.func,
+  }),
+  widgetFor: PropTypes.func,
+}
+
+export default ContactPagePreview

--- a/src/cms/preview-templates/ContactPagePreview.js
+++ b/src/cms/preview-templates/ContactPagePreview.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { ContactPageTemplate } from '../../pages/contact'
+import ContactPageTemplate from '../../templates/ContactPageTemplate'
 
 const ContactPagePreview = ({ entry, widgetFor }) => {
   return (

--- a/src/components/content.js
+++ b/src/components/content.js
@@ -1,0 +1,19 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+export const HTMLContent = ({ content, className }) => (
+  <div className={className} dangerouslySetInnerHTML={{ __html: content }} />
+)
+
+const Content = ({ content, className }) => (
+  <div className={className}>{content}</div>
+)
+
+Content.propTypes = {
+  content: PropTypes.node,
+  className: PropTypes.string,
+}
+
+HTMLContent.propTypes = Content.propTypes
+
+export default Content

--- a/src/pages/about.js
+++ b/src/pages/about.js
@@ -1,12 +1,6 @@
 import React from 'react'
-import Layout from '../components/layout'
-import IntroText from '../components/intro_text'
-import SEO from '../components/seo'
-import ImageOffset from '../components/image_offset'
-import Img from 'gatsby-image'
-import squigglyLine from '../images/about/squiggly-line.svg'
-import '../styles/pages/about.scss'
 import { graphql } from 'gatsby'
+import AboutPageTemplate from '../templates/AboutPageTemplate'
 
 const About = ({ data }) => {
   const {
@@ -19,135 +13,14 @@ const About = ({ data }) => {
   } = data.allMarkdownRemark.edges[0].node.frontmatter
 
   return (
-    <Layout>
-      <SEO title="About us" />
-      <IntroText headline={title} subheading={subheading} />
-
-      <section className="container">
-        <div className="row">
-          <div className="col-md-7">
-            <div className="row">
-              <div className="col-md-5">
-                <h2>{sectionOne.heading}</h2>
-              </div>
-              <div className="col-md-7">
-                <p>{sectionOne.text1}</p>
-              </div>
-            </div>
-            <div className="col-12 padding-top-30px padding-bottom-30px padding-bottom-md-none">
-              <ImageOffset
-                src={sectionOne.image.childImageSharp.fluid}
-                // backgroundColor={sectionOne.offsetimage.publicURL}
-                backgroundColor={'bg-map'}
-              />
-            </div>
-          </div>
-          <div className="col-md-5">
-            <p>{sectionOne.text2}</p>
-          </div>
-        </div>
-      </section>
-      <section className="container">
-        <div className="row">
-          <div className="col-md-7">
-            <div className="row">
-              <div className="col-md-5">
-                <h2>{sectionTwo.heading}t</h2>
-              </div>
-              <div className="col-md-7">
-                <p>{sectionTwo.column1}</p>
-              </div>
-            </div>
-          </div>
-          <div className="col-md-5">
-            {/* {sectionTwo.column2} */}
-            <p>
-              <b>NST aims to contribute in the following areas:</b>
-            </p>
-            <ul className="padding-left-15px">
-              <li>
-                Climate change with emphasis on reduction of global warming;
-              </li>
-              <li>
-                Advances in clean and renewable technologies and policies;
-              </li>
-              <li>A pollution-free, life-sustaining environment;</li>
-              <li>Inspiration for present and future generations</li>
-            </ul>
-          </div>
-        </div>
-      </section>
-      <section className="bg-sand">
-        <div className="container">
-          <div className="row">
-            <div className="col-12 text-center padding-bottom-60px">
-              <h2>{sectionThree.heading}</h2>
-            </div>
-            <div className="col-md-5 offset-md-1 padding-bottom-30px padding-bottom-md-none">
-              <div className="d-flex align-items-center margin-bottom-30px">
-                <Img
-                  fixed={
-                    sectionThree.boardMemberOne.image.childImageSharp.fixed
-                  }
-                />
-                <div className="padding-left-30px">
-                  <h3>{sectionThree.boardMemberOne.name}</h3>
-                  <img src={squigglyLine} alt="underline" />
-                </div>
-              </div>
-              <p>{sectionThree.boardMemberOne.text}</p>
-            </div>
-            <div className="col-md-5">
-              <div className="d-flex align-items-center margin-bottom-30px">
-                <Img
-                  fixed={
-                    sectionThree.boardMemberTwo.image.childImageSharp.fixed
-                  }
-                />
-                <div className="padding-left-30px">
-                  <h3>{sectionThree.boardMemberTwo.name}</h3>
-                  <img src={squigglyLine} alt="underline" />
-                </div>
-              </div>
-              <p>{sectionThree.boardMemberTwo.text}</p>
-            </div>
-          </div>
-        </div>
-      </section>
-      <section className="personell-bg">
-        <div className="container">
-          <div className="row">
-            <div className="col-12 text-center padding-bottom-60px">
-              <h2>{sectionFour.heading}</h2>
-            </div>
-            <div className="col-md-5 offset-md-1 padding-bottom-30px padding-bottom-md-none">
-              <div className="d-flex align-items-center margin-bottom-30px">
-                <Img
-                  fixed={sectionFour.employeeOne.image.childImageSharp.fixed}
-                />
-                <div className="padding-left-30px">
-                  <h3>{sectionFour.employeeOne.name}</h3>
-                  <img src={squigglyLine} alt="underline" />
-                </div>
-              </div>
-              <p>{sectionFour.employeeOne.text}</p>
-            </div>
-            <div className="col-md-5">
-              <div className="d-flex align-items-center margin-bottom-30px">
-                <Img
-                  fixed={sectionFour.employeeTwo.image.childImageSharp.fixed}
-                />
-                <div className="padding-left-30px">
-                  <h3>{sectionFour.employeeTwo.name}</h3>
-                  <img src={squigglyLine} alt="underline" />
-                </div>
-              </div>
-              <p>{sectionFour.employeeTwo.text}</p>
-            </div>
-          </div>
-        </div>
-      </section>
-    </Layout>
+    <AboutPageTemplate
+      title={title}
+      subheading={subheading}
+      sectionOne={sectionOne}
+      sectionTwo={sectionTwo}
+      sectionThree={sectionThree}
+      sectionFour={sectionFour}
+    />
   )
 }
 

--- a/src/pages/about.js
+++ b/src/pages/about.js
@@ -9,86 +9,41 @@ import '../styles/pages/about.scss'
 import { graphql } from 'gatsby'
 
 const About = ({ data }) => {
-  const treesImage = data.trees.childImageSharp.fluid
-  const peterNobelImage = data.peter.childImageSharp.fixed
-  const michaelNobelImage = data.michael.childImageSharp.fixed
-  const stinaNordlanderImage = data.stina.childImageSharp.fixed
-  const jamesBurtonImage = data.james.childImageSharp.fixed
+  const {
+    title,
+    subheading,
+    sectionOne,
+    sectionTwo,
+    sectionThree,
+    sectionFour,
+  } = data.allMarkdownRemark.edges[0].node.frontmatter
 
   return (
     <Layout>
       <SEO title="About us" />
-      <IntroText
-        headline="About us"
-        subheading="We encourage research, development, action and implementation of sustainable solutions"
-      />
+      <IntroText headline={title} subheading={subheading} />
 
       <section className="container">
         <div className="row">
           <div className="col-md-7">
             <div className="row">
               <div className="col-md-5">
-                <h2>The Background of Nobel Sustainability Trust</h2>
+                <h2>{sectionOne.heading}</h2>
               </div>
               <div className="col-md-7">
-                <p>
-                  NST is a Swiss foundation, established in 2007 by four members
-                  of the Nobel family. Formerly known as the Nobel Charitable
-                  Trust, its name was changed to the Nobel Sustainability Trust
-                  in 2011 so as to represent its role and activities more
-                  accurately. To promote the activities described above NST will
-                  encourage research, development, action and implementation of
-                  sustainable solutions. A key component will be the creation of
-                  an Award for Sustainability. This award, given annually, will
-                  be an accolade for those who make outstanding contributions to
-                  sustainability.
-                </p>
+                <p>{sectionOne.text1}</p>
               </div>
             </div>
             <div className="col-12 padding-top-30px padding-bottom-30px padding-bottom-md-none">
-              <ImageOffset src={treesImage} backgroundColor="bg-map" />
+              <ImageOffset
+                src={sectionOne.image.childImageSharp.fluid}
+                // backgroundColor={sectionOne.offsetimage.publicURL}
+                backgroundColor={'bg-map'}
+              />
             </div>
           </div>
           <div className="col-md-5">
-            <p>
-              The winners will be presented with the award at a gala dinner held
-              in connection with a symposium, organised by NST, in major cities
-              around the world. NST, via its secretariat in Switzerland and its
-              representative offices in Sweden and Costa Rica, will assist in
-              the selection of universities from various countries, which will
-              collect the proposed projects and candidates. One of these will
-              also be the Award Coordinating University (the “ACU”), this
-              centre, in consultation with NST, will select and maintain the
-              list of sourcing universities. The ACU will form a committee, the
-              Sustainability Award Committee, which will have final say in the
-              selection of the award winners. This comittee will have members
-              from outside the ACU. NST will plan and manage the annual
-              conferences and related events.
-            </p>
-            <p>
-              This comittee will have members from outside the ACU. NST will
-              plan and manage the annual conferences and related events. It will
-              liaise with the media and issue invitations for the award
-              ceremonies. Stringent efforts will be made to ensure that the NST
-              Awards will be recognised, by all concerned, as being independent
-              of the traditional Nobel Prizes. NST’s financial support will come
-              from sovereign entities, family offices and corporations who
-              support its agenda. A clear understanding of the origin of these
-              funds is essential, so NST will work with licensed and registered
-              entities, which are regulated by the financial authorities in
-              their respective jurisdictions.
-            </p>
-            <p>
-              Funding has begun and success has already been achieved. In 2016,
-              Innovator Capital (ICL) a specialist investment bank in London,
-              facilitated the creation of the Nobel Sustainability Fund® (NSF).
-              The fund, seeded by the Constitutional Reserve Fund of Monaco,
-              with the support of H.S.H. Prince Albert II of Monaco and Stephen
-              Lansdown, co-founder of Hargreaves Lansdown, is a multi-geography
-              fund, managed by Earth Capital Partners (ECP), subsidiary of the
-              SET3 organisation, which accelerates the development and growth of
-              sustainable technology companies.
-            </p>
+            <p>{sectionOne.text2}</p>
           </div>
         </div>
       </section>
@@ -97,31 +52,15 @@ const About = ({ data }) => {
           <div className="col-md-7">
             <div className="row">
               <div className="col-md-5">
-                <h2>The Mission of the Nobel Sustainability Trust</h2>
+                <h2>{sectionTwo.heading}t</h2>
               </div>
               <div className="col-md-7">
-                <p>
-                  The Nobel family, founders of the Nobel Sustainability Trust
-                  (“NST”) have, with great concern, been observing the
-                  devastation of the world’s vital, natural and non-renewable
-                  resources. This overconsumption has led to an increase in
-                  global temperatures and pollution of land, food, water and
-                  air. The founders believe that the economic and social health
-                  of civilisation will, to a large extent, depend on the
-                  availability of energy and a sustainable approach to
-                  agriculture, forestry, industrial manufacturing and water
-                  reclamation. This will require substantial intellectual and
-                  financial effort. It is the aim of NST to assist with this
-                  process. The objective of NST is to improve quality of life,
-                  which is, today, threatened by pollution, climate change and
-                  depletion of natural resources. Sufficient food, water, air
-                  and energy, in clean conditions, is essential to reaching this
-                  objective.
-                </p>
+                <p>{sectionTwo.column1}</p>
               </div>
             </div>
           </div>
           <div className="col-md-5">
+            {/* {sectionTwo.column2} */}
             <p>
               <b>NST aims to contribute in the following areas:</b>
             </p>
@@ -142,71 +81,35 @@ const About = ({ data }) => {
         <div className="container">
           <div className="row">
             <div className="col-12 text-center padding-bottom-60px">
-              <h2>The board</h2>
+              <h2>{sectionThree.heading}</h2>
             </div>
             <div className="col-md-5 offset-md-1 padding-bottom-30px padding-bottom-md-none">
               <div className="d-flex align-items-center margin-bottom-30px">
-                <Img fixed={michaelNobelImage} />
+                <Img
+                  fixed={
+                    sectionThree.boardMemberOne.image.childImageSharp.fixed
+                  }
+                />
                 <div className="padding-left-30px">
-                  <h3>Michael Nobel</h3>
+                  <h3>{sectionThree.boardMemberOne.name}</h3>
                   <img src={squigglyLine} alt="underline" />
                 </div>
               </div>
-              <p>
-                The chairman of NST, university professor Michael Nobel, PhD,
-                participated in the introduction of magnetic resonance imaging
-                as European vice president of Fonar Corp. From 1991 to 2007 he
-                served as Executive Chairman of the MRAB Group, a company
-                providing MRI services to Swedish hospitals. From 1991 to 2006
-                he was Vice Chairman and Chairman of the Board of the Nobel
-                Family. He has been consultant to Unesco in Paris and the United
-                Nations Social Affairs Division in Geneva. Michael Nobel is
-                presently chairman or board member of six international
-                companies in medical diagnostics, treatment and information and
-                in five non-for-profit organizations.
-              </p>
-              <p>
-                He is appointed distinguished professor at the Advanced Research
-                Institute of Natural Science and Technology at Osaka City
-                University and as guest professor at the Seisa and Soka
-                Universities in Japan. Michael Nobel has received twelve
-                honorary doctorates and professorships from universities around
-                the world and fourteen other types of awards for his work in
-                medical innovation and conflict resolution as well as in other
-                fields.
-              </p>
+              <p>{sectionThree.boardMemberOne.text}</p>
             </div>
             <div className="col-md-5">
               <div className="d-flex align-items-center margin-bottom-30px">
-                <Img fixed={peterNobelImage} />
+                <Img
+                  fixed={
+                    sectionThree.boardMemberTwo.image.childImageSharp.fixed
+                  }
+                />
                 <div className="padding-left-30px">
-                  <h3>Peter Nobel</h3>
+                  <h3>{sectionThree.boardMemberTwo.name}</h3>
                   <img src={squigglyLine} alt="underline" />
                 </div>
               </div>
-              <p>
-                Peter Nobel co-founded the Swedish clean tech company HeatCore
-                AB which operates in the energy efficiency sector. The company
-                is developing and marketing a highly compact and efficient heat
-                cell for applications in the global heating industry. Peter has
-                a degree of Master of Science in Material Science and
-                Engineering from the Royal Institute of Technology in Stockholm
-                and a degree in business administration from Lund University.
-              </p>
-              <p>
-                He has a track record of over 25 years positioning companies for
-                success and market share growth in various industrial markets.
-                He possesses a long experience of holding executive positions in
-                sales and marketing, R&D and manufacturing functions in global
-                companies like Alfa Laval and SWEP International.
-              </p>
-              <p>
-                He has significant expertise in successfully navigating long
-                sales cycles for industrial components for various global
-                industry sectors and was instrumental for developing heat
-                transfer products into an exponential growth resulting in a €500
-                million worldwide market.
-              </p>
+              <p>{sectionThree.boardMemberTwo.text}</p>
             </div>
           </div>
         </div>
@@ -215,59 +118,31 @@ const About = ({ data }) => {
         <div className="container">
           <div className="row">
             <div className="col-12 text-center padding-bottom-60px">
-              <h2>Personell</h2>
+              <h2>{sectionFour.heading}</h2>
             </div>
             <div className="col-md-5 offset-md-1 padding-bottom-30px padding-bottom-md-none">
               <div className="d-flex align-items-center margin-bottom-30px">
-                <Img fixed={stinaNordlanderImage} />
+                <Img
+                  fixed={sectionFour.employeeOne.image.childImageSharp.fixed}
+                />
                 <div className="padding-left-30px">
-                  <h3>Stina Nordlander</h3>
+                  <h3>{sectionFour.employeeOne.name}</h3>
                   <img src={squigglyLine} alt="underline" />
                 </div>
               </div>
-              <p>
-                Miss Stina Nordlander graduated 2016 from junior college after
-                studying natural sciences with the focus on biology. After
-                graduating she worked as a natural science and mathematics
-                teacher for 10-11 year old school children at a middle level
-                school in the Northern Swedish town of Umeå.
-              </p>
-              <p>
-                Early in 2015, Stina Nordlander began working at a local refugee
-                accommodation as a Swedish teacher. Her programs went viral on
-                Youtube.
-              </p>
-              <p>
-                She has won multiple titles in beauty contests during recent
-                years placing second in the Miss World Sweden competition of
-                2015 and became the first runner-up for the Swedish
-                representative to the competition of Miss World 2015. She was
-                also crowned Miss Supranational Sweden 2015. Currently Miss
-                Nordlander is working as Chief Operating Officer and Office
-                Manager for the Nobel Sustainability Trust Foundation.
-              </p>
+              <p>{sectionFour.employeeOne.text}</p>
             </div>
             <div className="col-md-5">
               <div className="d-flex align-items-center margin-bottom-30px">
-                <Img fixed={jamesBurtonImage} />
+                <Img
+                  fixed={sectionFour.employeeTwo.image.childImageSharp.fixed}
+                />
                 <div className="padding-left-30px">
-                  <h3>James Burton</h3>
+                  <h3>{sectionFour.employeeTwo.name}</h3>
                   <img src={squigglyLine} alt="underline" />
                 </div>
               </div>
-              <p>
-                James is an expert in prize design and operations. He has
-                advised organisations such as the World Bank, NASA, Coca Cola,
-                Emerson Electric Co. and The Nigerian Ministry of Finance on
-                structuring their own prizes and contributed to widely read
-                books on the subject.
-              </p>
-              <p>
-                Previously he served as Chief of Staff to XPRIZE founder Peter
-                Diamandis and as head of prize development at HeroX. James holds
-                an MSc and MBA from the University of Oxford, where he was a
-                Pershing Square Scholar.
-              </p>
+              <p>{sectionFour.employeeTwo.text}</p>
             </div>
           </div>
         </div>
@@ -285,38 +160,87 @@ export const pageQuery = graphql`
         title
       }
     }
-    trees: file(relativePath: { eq: "about/trees2.jpg" }) {
-      childImageSharp {
-        fluid(maxWidth: 960) {
-          ...GatsbyImageSharpFluid
-        }
-      }
-    }
-    peter: file(relativePath: { eq: "about/peter.png" }) {
-      childImageSharp {
-        fixed(width: 100) {
-          ...GatsbyImageSharpFixed
-        }
-      }
-    }
-    michael: file(relativePath: { eq: "about/michael.png" }) {
-      childImageSharp {
-        fixed(width: 100) {
-          ...GatsbyImageSharpFixed
-        }
-      }
-    }
-    stina: file(relativePath: { eq: "about/stina.png" }) {
-      childImageSharp {
-        fixed(width: 100) {
-          ...GatsbyImageSharpFixed
-        }
-      }
-    }
-    james: file(relativePath: { eq: "about/james.png" }) {
-      childImageSharp {
-        fixed(width: 100) {
-          ...GatsbyImageSharpFixed
+    allMarkdownRemark(
+      limit: 1
+      sort: { order: DESC, fields: [frontmatter___date] }
+      filter: { fileAbsolutePath: { regex: "/about/" } }
+    ) {
+      edges {
+        node {
+          frontmatter {
+            title
+            subheading
+            sectionOne {
+              heading
+              text1
+              text2
+              image {
+                childImageSharp {
+                  fluid(maxWidth: 960) {
+                    ...GatsbyImageSharpFluid
+                  }
+                }
+              }
+              offsetimage {
+                publicURL
+              }
+            }
+            sectionTwo {
+              heading
+              column1
+              column2
+            }
+            sectionThree {
+              heading
+              boardMemberOne {
+                name
+                text
+                image {
+                  childImageSharp {
+                    fixed(width: 100) {
+                      ...GatsbyImageSharpFixed
+                    }
+                  }
+                }
+              }
+              boardMemberTwo {
+                name
+                text
+                image {
+                  childImageSharp {
+                    fixed(width: 100) {
+                      ...GatsbyImageSharpFixed
+                    }
+                  }
+                }
+              }
+            }
+            sectionFour {
+              heading
+              employeeOne {
+                name
+                text
+                image {
+                  childImageSharp {
+                    fixed(width: 100) {
+                      ...GatsbyImageSharpFixed
+                    }
+                  }
+                }
+              }
+              employeeTwo {
+                name
+                text
+                image {
+                  childImageSharp {
+                    fixed(width: 100) {
+                      ...GatsbyImageSharpFixed
+                    }
+                  }
+                }
+              }
+            }
+          }
         }
       }
     }

--- a/src/pages/about.js
+++ b/src/pages/about.js
@@ -1,11 +1,12 @@
-import React from "react"
-import Layout from "../components/layout"
-import IntroText from "../components/intro_text"
-import SEO from "../components/seo"
-import ImageOffset from "../components/image_offset"
-import Img from "gatsby-image"
-import squigglyLine from "../images/about/squiggly-line.svg"
-import "../styles/pages/about.scss"
+import React from 'react'
+import Layout from '../components/layout'
+import IntroText from '../components/intro_text'
+import SEO from '../components/seo'
+import ImageOffset from '../components/image_offset'
+import Img from 'gatsby-image'
+import squigglyLine from '../images/about/squiggly-line.svg'
+import '../styles/pages/about.scss'
+import { graphql } from 'gatsby'
 
 const About = ({ data }) => {
   const treesImage = data.trees.childImageSharp.fluid

--- a/src/pages/awards.js
+++ b/src/pages/awards.js
@@ -2,12 +2,10 @@ import React from 'react'
 import Layout from '../components/layout'
 import SEO from '../components/seo'
 import IntroText from '../components/intro_text'
-import Img from 'gatsby-image'
 import '../styles/pages/awards.scss'
+import { graphql } from 'gatsby'
 
 const Awards = ({ data }) => {
-  const windmillImage = data.windmill.childImageSharp.fluid
-
   return (
     <Layout>
       <SEO title="Awards" />
@@ -130,7 +128,7 @@ const Awards = ({ data }) => {
       </section>
 
       <section>
-        <div className="container">
+        <div className="container padding-bottom-none">
           <div className="row">
             <h2 className="col-md-7 offset-md-3">
               The NST Conference on Sustainability
@@ -173,7 +171,7 @@ const Awards = ({ data }) => {
                 man bun selfies church-key brooklyn.
               </p>
               <p className="border-bottom"></p>
-              <h3>
+              <h3 className="c-water">
                 Each of the university comittees will propose a maximum of five
                 candidates
               </h3>
@@ -266,7 +264,7 @@ const Awards = ({ data }) => {
                 man bun selfies church-key brooklyn.
               </p>
               <p className="border-bottom"></p>
-              <h3>
+              <h3 className="c-water">
                 Each of the university comittees will propose a maximum of five
                 candidates
               </h3>
@@ -300,17 +298,49 @@ export const pageQuery = graphql`
         title
       }
     }
-    city: file(relativePath: { eq: "city.png" }) {
-      childImageSharp {
-        fluid(maxWidth: 960) {
-          ...GatsbyImageSharpFluid
-        }
-      }
-    }
-    windmill: file(relativePath: { eq: "windmill.png" }) {
-      childImageSharp {
-        fluid(maxWidth: 960) {
-          ...GatsbyImageSharpFluid
+    allMarkdownRemark(
+      limit: 1
+      sort: { order: DESC, fields: [frontmatter___date] }
+      filter: { fileAbsolutePath: { regex: "/awards/" } }
+    ) {
+      edges {
+        node {
+          frontmatter {
+            title
+            subheading
+            sectionOne {
+              heading
+              column1
+              column2
+            }
+            sectionTwo {
+              heading
+              subheading
+              text1
+              text2
+              text3
+            }
+            sectionThree {
+              heading
+              text
+            }
+            sectionFour {
+              heading
+              subheading
+              column1
+              column2
+            }
+            sectionFive {
+              heading
+              text
+            }
+            sectionSix {
+              heading
+              subheading
+              column1
+              column2
+            }
+          }
         }
       }
     }

--- a/src/pages/awards.js
+++ b/src/pages/awards.js
@@ -6,36 +6,31 @@ import '../styles/pages/awards.scss'
 import { graphql } from 'gatsby'
 
 const Awards = ({ data }) => {
+  const {
+    title,
+    subheading,
+    sectionOne,
+    sectionTwo,
+    sectionThree,
+    sectionFour,
+    sectionFive,
+    sectionSix,
+  } = data.allMarkdownRemark.edges[0].node.frontmatter
   return (
     <Layout>
       <SEO title="Awards" />
-      <IntroText
-        headline="Awards"
-        subheading="The Award will be given to scientists or institutions who have made important discoveries of potential importance to the wellbeing of mankind"
-      />
+      <IntroText headline={title} subheading={subheading} />
       <section>
         <div className="container">
           <div className="row">
             <div className="col-md-3">
-              <h2>Sustainability Award</h2>
+              <h2>{sectionOne.heading}</h2>
             </div>
             <div className="col-md-5 ">
-              <p>
-                Lorem ipsum dolor amet williamsburg adaptogen brooklyn small
-                batch etsy mlkshk sartorial biodiesel enamel pin chillwave blog
-                viral 90's. Lomo ethical tousled skateboard swag master cleanse
-                selvage neutra scenester. Cronut plaid YOLO woke tbh wolf
-                aesthetic. Post-ironic banh mi cold-pressed hashtag roof party.
-                Iceland vice aesthetic, raclette meggings pork belly bicycle
-                rights umami tousled pickled hexagon blue bottle. Skateboard
-                etsy succulents, mumblecore flexitarian hammock hella pabst
-                fashion axe tumeric lo-fi swag cronut. Everyday carry blog YOLO
-                air plant vegan keffiyeh viral four dollar toast. Taiyaki vegan
-                deep v, jean shorts cronut vexillologist ennui skateboard ramps
-                man bun selfies church-key brooklyn.
-              </p>
+              <p>{sectionOne.column1}</p>
             </div>
             <div className="col-md-4">
+              {/* {sectionOne.column2} */}
               <p>
                 <b>The Awards cermony will include:</b>
               </p>
@@ -55,43 +50,24 @@ const Awards = ({ data }) => {
       <section className="bg-grey-beige squiggly-line-bg">
         <div className="container padding-bottom-none windmill-bg">
           <h2 className="text-left-sm text-center-md padding-bottom-25px">
-            Award Selection Procedures
+            {sectionTwo.heading}
           </h2>
           <div className="row padding-bottom-60px">
             <div className="text-center-md col-md-10 offset-md-1 col-lg-8 offset-lg-2">
-              <p>
-                It was formed by the descendants of Immanuel Nobel the younger,
-                i.e. the fater of Alfred, Ludvig, Robert and Emil Nobel. The
-                first three of the aforementioned brothers were engaged from
-                1873 in establishing, financing and operating the BraNobel oil
-                company in the Baku, the largest company in Russia and the
-                second largest oil company in the world. The Nobel family is
-                also represented at the Nobel Prizes Award Ceremonies which are
-                held in Stockholm on the 10th of December every year since 1901.
-                In 2007, the Nobel family archives, kept in the town archives of
-                Lund, were inscribed in UNESCO's Memory of the World Register
-              </p>
+              <p>{sectionTwo.text1}</p>
             </div>
           </div>
           <div className="row padding-bottom-30px">
             <div className="col-md-3">
-              <h2>Role of the NST Representative</h2>
+              <h2>{sectionTwo.subheading}</h2>
             </div>
             <div className="col-md-9">
-              <p>
-                It was formed by the descendants of Immanuel Nobel the younger,
-                i.e. the fater of Alfred, Ludvig, Robert and Emil Nobel. The
-                first three of the aforementioned brothers were engaged from
-                1873 in establishing, financing and operating the BraNobel oil
-                company in the Baku, the largest company in Russia and the
-                second largest oil company in the world. The Nobel family is
-                also represented at the Nobel Prizes Award Ceremonies which are
-                held in Stockholm on the 10th of December every year since 1901.
-              </p>
+              <p>{sectionTwo.text2}</p>
             </div>
           </div>
           <div className="row">
             <div className="col-md-9 offset-md-3 col-lg-8 offset-lg-3">
+              {/* {sectionThree.text3} */}
               <p>
                 <b>The Awards cermony will include:</b>
               </p>
@@ -130,20 +106,12 @@ const Awards = ({ data }) => {
       <section>
         <div className="container padding-bottom-none">
           <div className="row">
-            <h2 className="col-md-7 offset-md-3">
-              The NST Conference on Sustainability
-            </h2>
+            <h2 className="col-md-7 offset-md-3">{sectionThree.heading}</h2>
           </div>
 
           <div className="row">
             <div className="col-md-7 offset-md-3">
-              <p>
-                It was formed by the descendants of Immanuel Nobel the younger,
-                i.e. the fater of Alfred, Ludvig, Robert and Emil Nobel. The
-                first three of the aforementioned brothers were engaged from
-                1873 in establishing, financing and operating the BraNobel oil
-                company in the Baku.
-              </p>
+              <p>{sectionThree.text}</p>
             </div>
           </div>
         </div>
@@ -153,52 +121,15 @@ const Awards = ({ data }) => {
         <div className="container">
           <div className="row">
             <div className="col-md-3">
-              <h2>The Role of the Universities in the NST Network</h2>
+              <h2>{sectionFour.heading}</h2>
             </div>
             <div className="col-md-4">
-              <p>
-                Lorem ipsum dolor amet williamsburg adaptogen brooklyn small
-                batch etsy mlkshk sartorial biodiesel enamel pin chillwave blog
-                viral 90's. Lomo ethical tousled skateboard swag master cleanse
-                selvage neutra scenester. Cronut plaid YOLO woke tbh wolf
-                aesthetic. Post-ironic banh mi cold-pressed hashtag roof party.
-                Iceland vice aesthetic, raclette meggings pork belly bicycle
-                rights umami tousled pickled hexagon blue bottle. Skateboard
-                etsy succulents, mumblecore flexitarian hammock hella pabst
-                fashion axe tumeric lo-fi swag cronut. Everyday carry blog YOLO
-                air plant vegan keffiyeh viral four dollar toast. Taiyaki vegan
-                deep v, jean shorts cronut vexillologist ennui skateboard ramps
-                man bun selfies church-key brooklyn.
-              </p>
+              <p>{sectionFour.column1}</p>
               <p className="border-bottom"></p>
-              <h3 className="c-water">
-                Each of the university comittees will propose a maximum of five
-                candidates
-              </h3>
+              <h3 className="c-water">{sectionFour.subheading}</h3>
             </div>
             <div className="col-md-4">
-              <p>
-                Lorem ipsum dolor amet williamsburg adaptogen brooklyn small
-                batch etsy mlkshk sartorial biodiesel enamel pin chillwave blog
-                viral 90's. Lomo ethical tousled skateboard swag master cleanse
-                selvage neutra scenester. Cronut plaid YOLO woke tbh wolf
-                aesthetic. Post-ironic banh mi cold-pressed hashtag roof party.
-                Iceland vice aesthetic, raclette meggings pork belly bicycle
-                rights umami tousled pickled hexagon blue bottle. Skateboard
-                etsy succulents, mumblecore flexitarian hammock hella pabst
-                fashion axe tumeric lo-fi swag cronut. Everyday carry blog YOLO
-                air plant vegan keffiyeh viral four dollar toast. Taiyaki vegan
-                deep v, jean shorts cronut vexillologist ennui skateboard ramps
-                man bun selfies church-key brooklyn. Post-ironic banh mi
-                cold-pressed hashtag roof party. Iceland vice aesthetic,
-                raclette meggings pork belly bicycle rights umami tousled
-                pickled hexagon blue bottle. Skateboard etsy succulents,
-                mumblecore flexitarian hammock hella pabst fashion axe tumeric
-                lo-fi swag cronut. Everyday carry blog YOLO air plant vegan
-                keffiyeh viral four dollar toast. Taiyaki vegan deep v, jean
-                shorts cronut vexillologist ennui skateboard ramps man bun
-                selfies church-key brooklyn
-              </p>
+              <p>{sectionFour.column2}</p>
             </div>
           </div>
         </div>
@@ -208,35 +139,10 @@ const Awards = ({ data }) => {
         <div className="container">
           <div className="row">
             <div className="col-md-3">
-              <h2>The Award Committee</h2>
+              <h2>{sectionFive.heading}</h2>
             </div>
             <div className="col-md-8">
-              <p>
-                Lorem ipsum dolor amet williamsburg adaptogen brooklyn small
-                batch etsy mlkshk sartorial biodiesel enamel pin chillwave blog
-                viral 90's. Lomo ethical tousled skateboard swag master cleanse
-                selvage neutra scenester. Cronut plaid YOLO woke tbh wolf
-                aesthetic. Post-ironic banh mi cold-pressed hashtag roof party.
-                Iceland vice aesthetic, raclette meggings pork belly bicycle
-                rights umami tousled pickled hexagon blue bottle. Skateboard
-                etsy succulents, mumblecore flexitarian hammock hella pabst
-                fashion axe tumeric lo-fi swag cronut. Everyday carry blog YOLO
-                air plant vegan keffiyeh viral four dollar toast. Taiyaki vegan
-                deep v, jean shorts cronut vexillologist ennui skateboard ramps
-                man bun selfies church-key brooklyn. Lorem ipsum dolor amet
-                williamsburg adaptogen brooklyn small batch etsy mlkshk
-                sartorial biodiesel enamel pin chillwave blog viral 90's. Lomo
-                ethical tousled skateboard swag master cleanse selvage neutra
-                scenester. Cronut plaid YOLO woke tbh wolf aesthetic.
-                Post-ironic banh mi cold-pressed hashtag roof party. Iceland
-                vice aesthetic, raclette meggings pork belly bicycle rights
-                umami tousled pickled hexagon blue bottle. Skateboard etsy
-                succulents, mumblecore flexitarian hammock hella pabst fashion
-                axe tumeric lo-fi swag cronut. Everyday carry blog YOLO air
-                plant vegan keffiyeh viral four dollar toast. Taiyaki vegan deep
-                v, jean shorts cronut vexillologist ennui skateboard ramps man
-                bun selfies church-key brooklyn.
-              </p>
+              <p>{sectionFive.text}</p>
             </div>
           </div>
         </div>
@@ -246,41 +152,15 @@ const Awards = ({ data }) => {
         <div className="container">
           <div className="row">
             <div className="col-md-3">
-              <h2>The Role of the Universities in the NST Network</h2>
+              <h2>{sectionSix.heading}</h2>
             </div>
             <div className="col-md-4">
-              <p>
-                Lorem ipsum dolor amet williamsburg adaptogen brooklyn small
-                batch etsy mlkshk sartorial biodiesel enamel pin chillwave blog
-                viral 90's. Lomo ethical tousled skateboard swag master cleanse
-                selvage neutra scenester. Cronut plaid YOLO woke tbh wolf
-                aesthetic. Post-ironic banh mi cold-pressed hashtag roof party.
-                Iceland vice aesthetic, raclette meggings pork belly bicycle
-                rights umami tousled pickled hexagon blue bottle. Skateboard
-                etsy succulents, mumblecore flexitarian hammock hella pabst
-                fashion axe tumeric lo-fi swag cronut. Everyday carry blog YOLO
-                air plant vegan keffiyeh viral four dollar toast. Taiyaki vegan
-                deep v, jean shorts cronut vexillologist ennui skateboard ramps
-                man bun selfies church-key brooklyn.
-              </p>
+              <p>{sectionSix.column1}</p>
               <p className="border-bottom"></p>
-              <h3 className="c-water">
-                Each of the university comittees will propose a maximum of five
-                candidates
-              </h3>
+              <h3 className="c-water">{sectionSix.subheading}</h3>
             </div>
             <div className="col-md-4">
-              <p>
-                Lorem ipsum dolor amet williamsburg adaptogen brooklyn small
-                batch etsy mlkshk sartorial biodiesel enamel pin chillwave blog
-                viral 90's. Lomo ethical tousled skateboard swag master cleanse
-                selvage neutra scenester. Cronut plaid YOLO woke tbh wolf
-                aesthetic. Post-ironic banh mi cold-pressed hashtag roof party.
-                Iceland vice aesthetic, raclette meggings pork belly bicycle
-                rights umami tousled pickled hexagon blue bottle. Skateboard
-                etsy succulents, mumblecore flexitarian hammock hella pabst
-                fashion axe tumeric lo-fi swag cronut.
-              </p>
+              <p>{sectionSix.column2}</p>
             </div>
           </div>
         </div>

--- a/src/pages/contact.js
+++ b/src/pages/contact.js
@@ -1,7 +1,7 @@
-import React from "react"
-import Layout from "../components/layout"
+import React from 'react'
+import Layout from '../components/layout'
 
-const Contact = () => {
+const Contact = ({ data }) => {
   return (
     <Layout>
       <div className="col-4">
@@ -12,3 +12,27 @@ const Contact = () => {
 }
 
 export default Contact
+
+export const pageQuery = graphql`
+  query {
+    site {
+      siteMetadata {
+        title
+      }
+    }
+    allMarkdownRemark(
+      limit: 1
+      sort: { order: DESC, fields: [frontmatter___date] }
+      filter: { fileAbsolutePath: { regex: "/history/" } }
+    ) {
+      edges {
+        node {
+          html
+          frontmatter {
+            title
+          }
+        }
+      }
+    }
+  }
+`

--- a/src/pages/contact.js
+++ b/src/pages/contact.js
@@ -1,27 +1,14 @@
 import React from 'react'
-import Layout from '../components/layout'
 import { graphql } from 'gatsby'
-import Content, { HTMLContent } from '../components/content'
+import { HTMLContent } from '../components/content'
+import ContactPageTemplate from '../templates/ContactPageTemplate'
 
-export const ContactPageTemplate = ({ title, content, contentComponent }) => {
-  const MarkDown = contentComponent || Content
-
-  return (
-    <Layout>
-      <div className="container">
-        <h2>{title}</h2>
-        <MarkDown className="col-md-6" content={content} />
-      </div>
-    </Layout>
-  )
-}
-
-const Contact = ({ data }) => {
+const ContactPage = ({ data }) => {
   const { html } = data.allMarkdownRemark.edges[0].node
   return <ContactPageTemplate content={html} contentComponent={HTMLContent} />
 }
 
-export default Contact
+export default ContactPage
 
 export const pageQuery = graphql`
   query {

--- a/src/pages/contact.js
+++ b/src/pages/contact.js
@@ -1,11 +1,17 @@
 import React from 'react'
 import Layout from '../components/layout'
+import { graphql } from 'gatsby'
 
 const Contact = ({ data }) => {
+  const { html } = data.allMarkdownRemark.edges[0].node
+  console.log(html)
   return (
     <Layout>
-      <div className="col-4">
-        <h1>Contact</h1>
+      <div className="container">
+        <div
+          className="col-md-6"
+          dangerouslySetInnerHTML={{ __html: html }}
+        ></div>
       </div>
     </Layout>
   )
@@ -23,7 +29,7 @@ export const pageQuery = graphql`
     allMarkdownRemark(
       limit: 1
       sort: { order: DESC, fields: [frontmatter___date] }
-      filter: { fileAbsolutePath: { regex: "/history/" } }
+      filter: { fileAbsolutePath: { regex: "/contact/" } }
     ) {
       edges {
         node {

--- a/src/pages/contact.js
+++ b/src/pages/contact.js
@@ -1,20 +1,24 @@
 import React from 'react'
 import Layout from '../components/layout'
 import { graphql } from 'gatsby'
+import Content, { HTMLContent } from '../components/content'
 
-const Contact = ({ data }) => {
-  const { html } = data.allMarkdownRemark.edges[0].node
-  console.log(html)
+export const ContactPageTemplate = ({ title, content, contentComponent }) => {
+  const MarkDown = contentComponent || Content
+
   return (
     <Layout>
       <div className="container">
-        <div
-          className="col-md-6"
-          dangerouslySetInnerHTML={{ __html: html }}
-        ></div>
+        <h2>{title}</h2>
+        <MarkDown className="col-md-6" content={content} />
       </div>
     </Layout>
   )
+}
+
+const Contact = ({ data }) => {
+  const { html } = data.allMarkdownRemark.edges[0].node
+  return <ContactPageTemplate content={html} contentComponent={HTMLContent} />
 }
 
 export default Contact

--- a/src/pages/history.js
+++ b/src/pages/history.js
@@ -70,36 +70,13 @@ const History = ({ data }) => {
         <div className="container">
           <div className="row">
             <div className="col-md-2">
-              <h3>The Nobel Foundation</h3>
+              <h3>{secondSection.heading}</h3>
             </div>
             <div className="col-md-5">
-              <p>
-                Lorem ipsum dolor amet williamsburg adaptogen brooklyn small
-                batch etsy mlkshk sartorial biodiesel enamel pin chillwave blog
-                viral 90's. Lomo ethical tousled skateboard swag master cleanse
-                selvage neutra scenester. Cronut plaid YOLO woke tbh wolf
-                aesthetic. Post-ironic banh mi cold-pressed hashtag roof party.
-                Iceland vice aesthetic, raclette meggings pork belly bicycle
-                rights umami tousled pickled hexagon blue bottle. Skateboard
-                etsy succulents, mumblecore flexitarian hammock hella pabst
-                fashion axe tumeric lo-fi swag cronut. Everyday carry blog YOLO
-                air plant vegan keffiyeh viral four dollar toast. Taiyaki vegan
-                deep v, jean shorts cronut vexillologist ennui skateboard ramps
-                man bun selfies church-key brooklyn.
-              </p>
+              <p>{secondSection.column1}</p>
             </div>
             <div className="col-md-5">
-              <p>
-                Lorem ipsum dolor amet williamsburg adaptogen brooklyn small
-                batch etsy mlkshk sartorial biodiesel enamel pin chillwave blog
-                viral 90's. Lomo ethical tousled skateboard swag master cleanse
-                selvage neutra scenester. Cronut plaid YOLO woke tbh wolf
-                aesthetic. Post-ironic banh mi cold-pressed hashtag roof party.
-                Iceland vice aesthetic, raclette meggings pork belly bicycle
-                rights umami tousled pickled hexagon blue bottle. Skateboard
-                etsy succulents, mumblecore flexitarian hammock hella pabst
-                fashion axe tumeric lo-fi swag cronut.
-              </p>
+              <p>{secondSection.column2}</p>
             </div>
           </div>
         </div>
@@ -108,11 +85,14 @@ const History = ({ data }) => {
       <section className="bg-grey-beige">
         <div className="container">
           <h2 className="text-left-sm text-center-md padding-bottom-45px">
-            The Nobel Family Society Today
+            {thirdSection.heading}
           </h2>
           <div className="row">
-            <div className="col-md-6">
-              <p>
+            <div
+              className="col-md-6"
+              dangerouslySetInnerHTML={{ __html: thirdSection.column1 }}
+            >
+              {/* <p>
                 <b>
                   The Nobel Family Society is a private association with the
                   following objectives
@@ -127,7 +107,7 @@ const History = ({ data }) => {
                 </li>
                 <li>A pollution-free, life-sustaining environment;</li>
                 <li>Inspiration for present and future generations</li>
-              </ul>
+              </ul> */}
             </div>
             <div className="col-md-6">
               <p>

--- a/src/pages/history.js
+++ b/src/pages/history.js
@@ -90,7 +90,7 @@ const History = ({ data }) => {
           <div className="row">
             <div
               className="col-md-6"
-              dangerouslySetInnerHTML={{ __html: thirdSection.column1 }}
+              // dangerouslySetInnerHTML={{ __html: body }}
             >
               {/* <p>
                 <b>

--- a/src/pages/history.js
+++ b/src/pages/history.js
@@ -4,6 +4,7 @@ import SEO from '../components/seo'
 import IntroText from '../components/intro_text'
 import ImageOffset from '../components/image_offset'
 import HistoryMidBreakpoint from '../components/history_mid_breakpoint'
+import { graphql } from 'gatsby'
 
 const History = ({ data }) => {
   const {
@@ -92,7 +93,7 @@ const History = ({ data }) => {
               className="col-md-6"
               // dangerouslySetInnerHTML={{ __html: body }}
             >
-              {/* <p>
+              <p>
                 <b>
                   The Nobel Family Society is a private association with the
                   following objectives
@@ -107,21 +108,10 @@ const History = ({ data }) => {
                 </li>
                 <li>A pollution-free, life-sustaining environment;</li>
                 <li>Inspiration for present and future generations</li>
-              </ul> */}
+              </ul>
             </div>
             <div className="col-md-6">
-              <p>
-                It was formed by the descendants of Immanuel Nobel the younger,
-                i.e. the father of Alfred, Ludvig, Robert and Emil Nobel. The
-                first three of the aforementioned brothers were engaged from
-                1873 in establishing, financing and operating the BraNobel oil
-                company in Baku, the largest company in Russia and the second
-                largest oil company in the world. The Nobel family is also
-                represented at the Nobel Prizes Award Ceremonies which are held
-                in Stockholm on the 10th of December every year since 1901. In
-                2007, the Nobel family archives, kept in the town archives of
-                Lund, were inscribed in UNESCO’s Memory of the World Register.
-              </p>
+              <p>{thirdSection.column2}</p>
             </div>
           </div>
         </div>

--- a/src/pages/history.js
+++ b/src/pages/history.js
@@ -6,26 +6,28 @@ import ImageOffset from '../components/image_offset'
 import HistoryMidBreakpoint from '../components/history_mid_breakpoint'
 
 const History = ({ data }) => {
-  const immanuelImage = data.immanuel.childImageSharp.fluid
-  const ludwigImage = data.ludwig.childImageSharp.fluid
+  const {
+    title,
+    subheading,
+    firstSection,
+    secondSection,
+    thirdSection,
+  } = data.allMarkdownRemark.edges[0].node.frontmatter
+
+  console.log(data)
 
   return (
     <Layout>
-      <SEO title="History" />
+      <SEO title={title} />
       <section>
-        <IntroText
-          headline="History"
-          subheading={[
-            'Members of the earlier Nobel family were known, not only',
-            <span className="d-md-block">
-              for their interest in art but also for their inventive ability
-            </span>,
-          ]}
-        />
+        <IntroText headline="History" subheading={subheading} />
       </section>
       <section className="padding-top-none d-none d-block d-lg-none">
         <div className="container">
-          <HistoryMidBreakpoint ludwig={ludwigImage} immanuel={immanuelImage} />
+          <HistoryMidBreakpoint
+            ludwig={firstSection.image1.childImageSharp.fluid}
+            immanuel={firstSection.image2.childImageSharp.fluid}
+          />
         </div>
       </section>
 
@@ -33,43 +35,28 @@ const History = ({ data }) => {
         <div className="container">
           <div className="row padding-bottom-60px">
             <div className="col-lg-3">
-              <ImageOffset src={immanuelImage} backgroundColor={'bg-water'} />
+              <ImageOffset
+                src={firstSection.image1.childImageSharp.fluid}
+                backgroundColor={'bg-water'}
+              />
             </div>
             <div className="col-lg-9">
               <div className="row">
                 <div className="col-lg-5">
-                  <h2>Immanuel Nobel</h2>
-                  <p>
-                    Immanuel Nobel pioneered the development of underwater
-                    mines, designed some of the first steam engines to power
-                    russian ships, installed the first central heating systems
-                    in Russian homes and was the first to develop modern
-                    plywood, cut with a rotary lathe.
-                  </p>
+                  <h2>{firstSection.heading1}</h2>
+                  <p>{firstSection.text1}</p>
                 </div>
                 <div className="col-lg-12">
                   <div className="row padding-top-60px">
                     <div className="offset-lg-1 col-lg-4">
                       <ImageOffset
-                        src={ludwigImage}
+                        src={firstSection.image2.childImageSharp.fluid}
                         backgroundColor={'bg-green'}
                       />
                     </div>
                     <div className="col-lg-6">
-                      <h2>Ludwig Nobel</h2>
-                      <p>
-                        One of his sons, Ludvig Nobel, was the founder of the
-                        machine-building factory Ludvig Nobel, a great armaments
-                        concern and the inventor of the Nobel wheel. Ludvig was
-                        also the founder of BraNobel, the foremost Russian oil
-                        industry in it's time, and launched the world's first
-                        diesel-driven tugs, tankers and u-boats, besides
-                        building the first European oil pipeline in Baku. Alfred
-                        Nobel, a profilic inventor who acquired 355 patents
-                        during his lifespan, was the creator of dynamite and the
-                        blasting cap from which he made a substantial future of
-                        which he left the bulk to form the Nobel Prizes.
-                      </p>
+                      <h2>{firstSection.heading2}</h2>
+                      <p>{firstSection.text2}</p>
                     </div>
                   </div>
                 </div>
@@ -172,17 +159,47 @@ export const pageQuery = graphql`
         title
       }
     }
-    immanuel: file(relativePath: { eq: "immanuel.jpg" }) {
-      childImageSharp {
-        fluid(maxWidth: 960) {
-          ...GatsbyImageSharpFluid
-        }
-      }
-    }
-    ludwig: file(relativePath: { eq: "ludwig.jpg" }) {
-      childImageSharp {
-        fluid(maxWidth: 960) {
-          ...GatsbyImageSharpFluid
+    allMarkdownRemark(
+      limit: 1
+      sort: { order: DESC, fields: [frontmatter___date] }
+      filter: { fileAbsolutePath: { regex: "/history/" } }
+    ) {
+      edges {
+        node {
+          frontmatter {
+            title
+            subheading
+            firstSection {
+              heading1
+              heading2
+              text1
+              text2
+              image1 {
+                childImageSharp {
+                  fluid(maxWidth: 960) {
+                    ...GatsbyImageSharpFluid
+                  }
+                }
+              }
+              image2 {
+                childImageSharp {
+                  fluid(maxWidth: 960) {
+                    ...GatsbyImageSharpFluid
+                  }
+                }
+              }
+            }
+            secondSection {
+              heading
+              column1
+              column2
+            }
+            thirdSection {
+              heading
+              column1
+              column2
+            }
+          }
         }
       }
     }

--- a/src/templates/AboutPageTemplate.js
+++ b/src/templates/AboutPageTemplate.js
@@ -1,0 +1,151 @@
+import React from 'react'
+import Layout from '../components/layout'
+import IntroText from '../components/intro_text'
+import SEO from '../components/seo'
+import ImageOffset from '../components/image_offset'
+import Img from 'gatsby-image'
+import squigglyLine from '../images/about/squiggly-line.svg'
+import '../styles/pages/about.scss'
+
+const AboutPageTemplate = ({
+  title,
+  subheading,
+  sectionOne,
+  sectionTwo,
+  sectionThree,
+  sectionFour,
+}) => {
+  return (
+    <Layout>
+      <SEO title="About us" />
+      <IntroText headline={title} subheading={subheading} />
+
+      <section className="container">
+        <div className="row">
+          <div className="col-md-7">
+            <div className="row">
+              <div className="col-md-5">
+                <h2>{sectionOne.heading}</h2>
+              </div>
+              <div className="col-md-7">
+                <p>{sectionOne.text1}</p>
+              </div>
+            </div>
+            <div className="col-12 padding-top-30px padding-bottom-30px padding-bottom-md-none">
+              <ImageOffset
+                src={sectionOne.image.childImageSharp.fluid}
+                // backgroundColor={sectionOne.offsetimage.publicURL}
+                backgroundColor={'bg-map'}
+              />
+            </div>
+          </div>
+          <div className="col-md-5">
+            <p>{sectionOne.text2}</p>
+          </div>
+        </div>
+      </section>
+      <section className="container">
+        <div className="row">
+          <div className="col-md-7">
+            <div className="row">
+              <div className="col-md-5">
+                <h2>{sectionTwo.heading}t</h2>
+              </div>
+              <div className="col-md-7">
+                <p>{sectionTwo.column1}</p>
+              </div>
+            </div>
+          </div>
+          <div className="col-md-5">
+            {/* {sectionTwo.column2} */}
+            <p>
+              <b>NST aims to contribute in the following areas:</b>
+            </p>
+            <ul className="padding-left-15px">
+              <li>
+                Climate change with emphasis on reduction of global warming;
+              </li>
+              <li>
+                Advances in clean and renewable technologies and policies;
+              </li>
+              <li>A pollution-free, life-sustaining environment;</li>
+              <li>Inspiration for present and future generations</li>
+            </ul>
+          </div>
+        </div>
+      </section>
+      <section className="bg-sand">
+        <div className="container">
+          <div className="row">
+            <div className="col-12 text-center padding-bottom-60px">
+              <h2>{sectionThree.heading}</h2>
+            </div>
+            <div className="col-md-5 offset-md-1 padding-bottom-30px padding-bottom-md-none">
+              <div className="d-flex align-items-center margin-bottom-30px">
+                <Img
+                  fixed={
+                    sectionThree.boardMemberOne.image.childImageSharp.fixed
+                  }
+                />
+                <div className="padding-left-30px">
+                  <h3>{sectionThree.boardMemberOne.name}</h3>
+                  <img src={squigglyLine} alt="underline" />
+                </div>
+              </div>
+              <p>{sectionThree.boardMemberOne.text}</p>
+            </div>
+            <div className="col-md-5">
+              <div className="d-flex align-items-center margin-bottom-30px">
+                <Img
+                  fixed={
+                    sectionThree.boardMemberTwo.image.childImageSharp.fixed
+                  }
+                />
+                <div className="padding-left-30px">
+                  <h3>{sectionThree.boardMemberTwo.name}</h3>
+                  <img src={squigglyLine} alt="underline" />
+                </div>
+              </div>
+              <p>{sectionThree.boardMemberTwo.text}</p>
+            </div>
+          </div>
+        </div>
+      </section>
+      <section className="personell-bg">
+        <div className="container">
+          <div className="row">
+            <div className="col-12 text-center padding-bottom-60px">
+              <h2>{sectionFour.heading}</h2>
+            </div>
+            <div className="col-md-5 offset-md-1 padding-bottom-30px padding-bottom-md-none">
+              <div className="d-flex align-items-center margin-bottom-30px">
+                <Img
+                  fixed={sectionFour.employeeOne.image.childImageSharp.fixed}
+                />
+                <div className="padding-left-30px">
+                  <h3>{sectionFour.employeeOne.name}</h3>
+                  <img src={squigglyLine} alt="underline" />
+                </div>
+              </div>
+              <p>{sectionFour.employeeOne.text}</p>
+            </div>
+            <div className="col-md-5">
+              <div className="d-flex align-items-center margin-bottom-30px">
+                <Img
+                  fixed={sectionFour.employeeTwo.image.childImageSharp.fixed}
+                />
+                <div className="padding-left-30px">
+                  <h3>{sectionFour.employeeTwo.name}</h3>
+                  <img src={squigglyLine} alt="underline" />
+                </div>
+              </div>
+              <p>{sectionFour.employeeTwo.text}</p>
+            </div>
+          </div>
+        </div>
+      </section>
+    </Layout>
+  )
+}
+
+export default AboutPageTemplate

--- a/src/templates/ContactPageTemplate.js
+++ b/src/templates/ContactPageTemplate.js
@@ -1,0 +1,18 @@
+import React from 'react'
+import Layout from '../components/layout'
+import Content from '../components/content'
+
+const ContactPageTemplate = ({ title, content, contentComponent }) => {
+  const MarkDown = contentComponent || Content
+
+  return (
+    <Layout>
+      <div className="container">
+        <h2>{title}</h2>
+        <MarkDown className="col-md-6" content={content} />
+      </div>
+    </Layout>
+  )
+}
+
+export default ContactPageTemplate

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -164,7 +164,7 @@ collections:
   - name: 'about'
     label: About
     folder: src/cms/about
-    create: true
+    create: false
     slug: '{{year}}-{{month}}-{{day}}-{{slug}}'
     editor:
       preview: true
@@ -192,20 +192,36 @@ collections:
         widget: object
         fields:
           - { label: heading, name: heading, widget: string }
-          - { label: subheading 1, name: subheading1, widget: string }
-          - { label: text 1, name: text1, widget: markdown }
-          - { label: image 1, name: image1, widget: image }
-          - { label: subheading 2, name: subheading2, widget: string }
-          - { label: text 2, name: text2, widget: markdown }
-          - { label: image 2, name: image2, widget: image }
+          - label: Board Member One
+            name: boardMemberOne
+            widget: object
+            fields:
+              - { label: name, name: name, widget: string }
+              - { label: text, name: text, widget: markdown }
+              - { label: image, name: image, widget: image }
+          - label: Board Member Two
+            name: boardMemberTwo
+            widget: object
+            fields:
+              - { label: name, name: name, widget: string }
+              - { label: text, name: text, widget: markdown }
+              - { label: image, name: image, widget: image }
       - label: Section Four
         name: sectionFour
         widget: object
         fields:
           - { label: heading, name: heading, widget: string }
-          - { label: subheading 1, name: subheading1, widget: string }
-          - { label: text 1, name: text1, widget: markdown }
-          - { label: image 1, name: image1, widget: image }
-          - { label: subheading 2, name: subheading2, widget: string }
-          - { label: text 2, name: text2, widget: markdown }
-          - { label: image 2, name: image2, widget: image }
+          - label: Employee One
+            name: employeeOne
+            widget: object
+            fields:
+              - { label: name, name: name, widget: string }
+              - { label: text, name: text, widget: markdown }
+              - { label: image, name: image, widget: image }
+          - label: Employee Two
+            name: employeeTwo
+            widget: object
+            fields:
+              - { label: name, name: name, widget: string }
+              - { label: text, name: text, widget: markdown }
+              - { label: image, name: image, widget: image }

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -94,6 +94,13 @@ collections:
           - { label: heading, name: heading, widget: string }
           - { label: column 1, name: column1, widget: markdown }
           - { label: column 2, name: column2, widget: markdown }
-      - label: Test
-        name: body
-      - { label: 'Blog post content', name: 'body', widget: 'markdown' }
+  - name: 'contact'
+    label: Contact
+    folder: src/cms/contact
+    create: true
+    slug: '{{year}}-{{month}}-{{day}}-{{slug}}'
+    editor:
+      preview: true
+    fields:
+      - { label: 'Title', name: 'title', widget: 'string' }
+      - { label: 'Body', name: 'body', widget: 'markdown' }

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -94,3 +94,6 @@ collections:
           - { label: heading, name: heading, widget: string }
           - { label: column 1, name: column1, widget: markdown }
           - { label: column 2, name: column2, widget: markdown }
+      - label: Test
+        name: body
+      - { label: 'Blog post content', name: 'body', widget: 'markdown' }

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -160,3 +160,52 @@ collections:
           - { label: column 1, name: column1, widget: markdown }
           - { label: subheading, name: subheading, widget: string }
           - { label: column 2, name: column2, widget: markdown }
+
+  - name: 'about'
+    label: About
+    folder: src/cms/about
+    create: true
+    slug: '{{year}}-{{month}}-{{day}}-{{slug}}'
+    editor:
+      preview: true
+    fields:
+      - { label: 'Title', name: 'title', widget: 'string' }
+      - { label: Subheading, name: subheading, widget: string }
+      - label: Section One
+        name: sectionOne
+        widget: object
+        fields:
+          - { label: heading, name: heading, widget: string }
+          - { label: text 1, name: text1, widget: markdown }
+          - { label: text 2, name: text2, widget: markdown }
+          - { label: image, name: image, widget: image }
+          - { label: offset image, name: offsetimage, widget: image }
+      - label: Section Two
+        name: sectionTwo
+        widget: object
+        fields:
+          - { label: heading, name: heading, widget: string }
+          - { label: column 1, name: column1, widget: markdown }
+          - { label: column 2, name: column2, widget: markdown }
+      - label: Section Three
+        name: sectionThree
+        widget: object
+        fields:
+          - { label: heading, name: heading, widget: string }
+          - { label: subheading 1, name: subheading1, widget: string }
+          - { label: text 1, name: text1, widget: markdown }
+          - { label: image 1, name: image1, widget: image }
+          - { label: subheading 2, name: subheading2, widget: string }
+          - { label: text 2, name: text2, widget: markdown }
+          - { label: image 2, name: image2, widget: image }
+      - label: Section Four
+        name: sectionFour
+        widget: object
+        fields:
+          - { label: heading, name: heading, widget: string }
+          - { label: subheading 1, name: subheading1, widget: string }
+          - { label: text 1, name: text1, widget: markdown }
+          - { label: image 1, name: image1, widget: image }
+          - { label: subheading 2, name: subheading2, widget: string }
+          - { label: text 2, name: text2, widget: markdown }
+          - { label: image 2, name: image2, widget: image }

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -139,7 +139,7 @@ collections:
           - { label: heading, name: heading, widget: string }
           - { label: text, name: text, widget: markdown }
       - label: Section Four
-        name: sectionTFour
+        name: sectionFour
         widget: object
         fields:
           - { label: heading, name: heading, widget: string }

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -59,3 +59,38 @@ collections:
         searchFields: ['title']
         valueField: 'title'
         displayFields: ['title']
+
+  - name: history
+    label: History
+    folder: src/cms/history
+    create: true
+    slug: '{{year}}-{{month}}-{{day}}-{{slug}}'
+    editor:
+      preview: true
+    fields:
+      - { label: Title, name: title, widget: string }
+      - { label: Subheading, name: subheading, widget: string }
+      - label: First section
+        name: firstSection
+        widget: object
+        fields:
+          - { label: heading 1, name: heading1, widget: string }
+          - { label: text 1, name: text1, widget: markdown }
+          - { lebel: image 1, name: image1, widget: image }
+          - { label: heading 2, name: heading2, widget: string }
+          - { label: text 2, name: text2, widget: markdown }
+          - { label: image 2, name: image2, widget: image }
+      - label: Second section
+        name: secondSection
+        widget: object
+        fields:
+          - { label: heading, name: heading, widget: string }
+          - { label: column 1, name: column1, widget: markdown }
+          - { label: column 2, name: column2, widget: markdown }
+      - label: Third section
+        name: thirdSection
+        widget: object
+        fields:
+          - { label: heading, name: heading, widget: string }
+          - { label: column 1, name: column1, widget: markdown }
+          - { label: column 2, name: column2, widget: markdown }

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -22,7 +22,7 @@ collections:
   - name: home
     label: Home
     folder: src/cms/home
-    create: true
+    create: false
     slug: '{{year}}-{{month}}-{{day}}-{{slug}}'
     editor:
       preview: true
@@ -63,7 +63,7 @@ collections:
   - name: history
     label: History
     folder: src/cms/history
-    create: true
+    create: false
     slug: '{{year}}-{{month}}-{{day}}-{{slug}}'
     editor:
       preview: true
@@ -94,13 +94,69 @@ collections:
           - { label: heading, name: heading, widget: string }
           - { label: column 1, name: column1, widget: markdown }
           - { label: column 2, name: column2, widget: markdown }
+
   - name: 'contact'
     label: Contact
     folder: src/cms/contact
-    create: true
+    create: false
     slug: '{{year}}-{{month}}-{{day}}-{{slug}}'
     editor:
       preview: true
     fields:
       - { label: 'Title', name: 'title', widget: 'string' }
       - { label: 'Body', name: 'body', widget: 'markdown' }
+
+  - name: 'awards'
+    label: Awards
+    folder: src/cms/awards
+    create: false
+    slug: '{{year}}-{{month}}-{{day}}-{{slug}}'
+    editor:
+      preview: true
+    fields:
+      - { label: Title, name: title, widget: string }
+      - { label: Subheading, name: subheading, widget: string }
+      - label: Section One
+        name: sectionOne
+        widget: object
+        fields:
+          - { label: heading, name: heading, widget: string }
+          - { label: column 1, name: column1, widget: markdown }
+          - { label: column 2, name: column2, widget: markdown }
+      - label: Section Two
+        name: sectionTwo
+        widget: object
+        fields:
+          - { label: heading, name: heading, widget: string }
+          - { label: text 1, name: text1, widget: markdown }
+          - { label: subheading, name: subheading, widget: string }
+          - { label: text 2, name: text2, widget: markdown }
+          - { label: text 3, name: text3, widget: markdown }
+      - label: Section Three
+        name: sectionThree
+        widget: object
+        fields:
+          - { label: heading, name: heading, widget: string }
+          - { label: text, name: text, widget: markdown }
+      - label: Section Four
+        name: sectionTFour
+        widget: object
+        fields:
+          - { label: heading, name: heading, widget: string }
+          - { label: column 1, name: column1, widget: markdown }
+          - { label: subheading, name: subheading, widget: string }
+          - { label: column 2, name: column2, widget: markdown }
+      - label: Section Five
+        name: sectionFive
+        widget: object
+        fields:
+          - { label: heading, name: heading, widget: string }
+          - { label: text, name: text, widget: markdown }
+      - label: Section Six
+        name: sectionSix
+        widget: object
+        fields:
+          - { label: heading, name: heading, widget: string }
+          - { label: column 1, name: column1, widget: markdown }
+          - { label: subheading, name: subheading, widget: string }
+          - { label: column 2, name: column2, widget: markdown }


### PR DESCRIPTION
- All pages now renders content from CMS
- Contact-page renders markdown
- Add preview-template for contact-page (this should be done to all pages to improve user experience in Netlify CMS)
- Remains to fix issue where you can't render more than 1 markdown-prop per page